### PR TITLE
Add Index health check class

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Contents
    waiter
    exists
    health
+   index_health
    ilm
    relocate
    restore

--- a/docs/index_health.rst
+++ b/docs/index_health.rst
@@ -1,0 +1,12 @@
+.. _index_health:
+
+Index Class
+###########
+
+Index
+=====
+
+.. autoclass:: es_wait.index.Index
+   :members:
+   :show-inheritance:
+   :inherited-members:

--- a/src/es_wait/__init__.py
+++ b/src/es_wait/__init__.py
@@ -1,8 +1,9 @@
 """Top-level init file"""
 
-__version__ = '0.8.0'
+__version__ = '0.9.0'
 from .exists import Exists
 from .health import Health
+from .index import Index
 from .ilm import IlmPhase, IlmStep
 from .relocate import Relocate
 from .restore import Restore
@@ -12,6 +13,7 @@ from .task import Task
 __all__ = [
     'Exists',
     'Health',
+    'Index',
     'IlmPhase',
     'IlmStep',
     'Relocate',

--- a/src/es_wait/index.py
+++ b/src/es_wait/index.py
@@ -1,0 +1,118 @@
+"""Health Check Waiter"""
+
+import typing as t
+import logging
+from ._base import Waiter
+
+if t.TYPE_CHECKING:
+    from elasticsearch8 import Elasticsearch
+
+logger = logging.getLogger(__name__)
+
+# pylint: disable=R0913
+
+
+class Index(Waiter):
+    """Wait for index health check to have an expected value"""
+
+    ACTIONS = ['allocation', 'cluster_routing', 'mount', 'replicas', 'shrink']
+    HEALTH_ACTIONS = ['health', 'mount', 'replicas', 'shrink']
+    HEALTH_ARGS = {'health': 'green'}
+
+    def __init__(
+        self,
+        client: 'Elasticsearch',
+        pause: float = 1.5,
+        timeout: float = 15,
+        action: t.Literal['health', 'mount', 'replicas', 'shrink'] = None,
+        index: str = None,
+    ) -> None:
+        super().__init__(client=client, pause=pause, timeout=timeout)
+        #: The action determines the kind of response we look for in the health check
+        self.action = action
+        self.index = index
+        self.empty_check('action')
+        self.empty_check('index')
+        self.resolve_index()
+        self.waitstr = self.getwaitstr
+        self.do_health_report = True
+        logger.debug('Waiting %s...', self.waitstr)
+
+    def argmap(self) -> t.Union[t.Dict[str, int], t.Dict[str, str]]:
+        """
+        This method ensures that we are processing the correct arguments based on
+        :py:attr:`action`
+        """
+        if self.action in self.HEALTH_ACTIONS:
+            return self.HEALTH_ARGS
+        msg = f'{self.action} is not an acceptable value for action'
+        logger.error(msg)
+        raise ValueError(msg)
+
+    @property
+    def check(self) -> bool:
+        """
+        This function calls :py:meth:`cat.indices()
+        <elasticsearch.client.CatClient.indices>` and, based on the
+        return value from :py:meth:`argmap`, will return ``True`` or ``False``
+        depending on whether that particular keyword appears in the output, and has the
+        expected value.
+
+        If multiple keys are provided, all must match for a ``True`` response.
+
+        :getter: Returns if the check was complete
+        :type: bool
+        """
+        res = self.client.cat.indices(index=self.index, format='json', h='health')
+        logger.debug('res = %s', res)
+        logger.debug('type(res) = %s', type(res))
+        output = res[0]
+        check = True
+        args = self.argmap()
+        for key, value in args.items():
+            # First, verify that the key is in output
+            if key not in output:
+                raise KeyError(f'Key "{key}" not in index health output')
+            # Verify that the output matches the expected value
+            if output[key] != value:
+                msg = (
+                    f'NO MATCH: Value for key "{value}", index health check output: '
+                    f'{output[key]}'
+                )
+                logger.debug(msg)
+                check = False  # We do not match
+            else:
+                msg = (
+                    f'MATCH: Value for key "{value}", index health check output: '
+                    f'{output[key]}'
+                )
+                logger.debug(msg)
+        if check:
+            logger.debug('Index health check for action %s passed.', self.action)
+        return check
+
+    def resolve_index(self) -> None:
+        """
+        Resolve whether the value of :py:attr:`index` is an index of the same
+        name, or something else.
+        """
+        resp = self.client.indices.resolve_index(name=self.index)
+        if len(resp['indices']) == 0:  # This is bad, it should be one
+            raise ValueError(f'{self.index} resolves to zero indices: {resp}')
+        if len(resp['indices']) > 1:  # This is bad, it should only be one
+            raise ValueError(f'{self.index} resolves to more than one index: {resp}')
+        if resp['indices'][0]['name'] != self.index:  # An alias?
+            raise ValueError(f'{self.index} does not resolve to itself: {resp}')
+
+    @property
+    def getwaitstr(self) -> t.AnyStr:
+        """
+        Define the waitstr based on :py:attr:`action`
+
+        :getter: Returns the proper waitstr
+        :type: str
+        """
+        retval = None
+        if self.action in self.HEALTH_ACTIONS:
+            retval = 'for index health to show green status'
+        return retval

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -26,6 +26,9 @@ CLUSTER_HEALTH = {
     "task_max_waiting_in_queue_millis": 0,
     "active_shards_percent_as_number": 100,
 }
+INDEX_HEALTH = [{"health": "green"}]
+INDEX_NAME = 'index_name'
+INDEX_RESOLVE = {'indices': [{'name': INDEX_NAME}], 'aliases': [], 'data_streams': []}
 FAKE_FAIL = Exception('Simulated Failure')
 GENERIC_TASK = {'task': 'I0ekFjMhSPCQz7FUs1zJOg:54510686'}
 NAMED_INDICES = ["index-2015.01.01", "index-2015.02.01"]
@@ -148,6 +151,30 @@ def ilm_test(client, named_index):
         return bool(ic.check is result)
 
     return _ilm_test
+
+
+@pytest.fixture(scope='function')
+def index_health():
+    return INDEX_HEALTH
+
+
+@pytest.fixture(scope='function')
+def idx():
+    return INDEX_NAME
+
+
+@pytest.fixture(scope='function')
+def idx_resolve():
+    return INDEX_RESOLVE
+
+
+@pytest.fixture(scope='function')
+def indexhc(client, index_health, idx_resolve):
+    def _indexhc(retval=index_health, resolve=idx_resolve):
+        client.cat.indices.return_value = retval
+        client.indices.resolve_index.return_value = resolve
+
+    return _indexhc
 
 
 @pytest.fixture(scope='function')

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,0 +1,76 @@
+"""Unit tests for Index"""
+
+import pytest
+from es_wait import Index
+
+FAKE_FAIL = Exception('Simulated Failure')
+
+# pylint: disable=W0104
+
+
+class TestIndex:
+    """TestIndex
+
+    Test Index class
+    """
+
+    def test_key_value_match(self, client, indexhc, idx):
+        """test_key_value_match
+        Should return ``True`` when matching keyword args are passed.
+        """
+        indexhc()
+        hc = Index(client, action='health', index=idx)
+        assert hc.check
+
+    def test_key_value_negative(self, client, indexhc, idx):
+        """test_key_value_negative
+        Should return ``False`` when a negative response value is found
+        """
+        indexhc([{"health": "red"}])
+        hc = Index(client, action='health', index=idx)
+        assert not hc.check
+
+    def test_resolve_negative(self, client, indexhc, idx):
+        """test_resolve_negative
+        Should raise ``ValueError` when the index does not resolve
+        """
+        tval = {'indices': [{'name': 'nomatch'}], 'aliases': [], 'data_streams': []}
+        indexhc([{"health": "green"}], tval)
+        with pytest.raises(ValueError, match=r'does not resolve to itself'):
+            _ = Index(client, action='health', index=idx)
+
+    def test_resolve_no_indices(self, client, indexhc, idx):
+        """test_resolve_no_indices
+        Should raise ``ValueError`` when there are no indices in response
+        """
+        tval = {'indices': [], 'aliases': [{'name': idx, 'indices': []}]}
+        indexhc([{"health": "green"}], tval)
+        with pytest.raises(ValueError, match=r'resolves to zero indices'):
+            _ = Index(client, action='health', index=idx)
+
+    def test_resolve_multiple(self, client, indexhc, idx):
+        """test_resolve_multiple
+        Should raise ``ValueError` when there are no indices in response
+        """
+        tval = {'indices': [{'name': 'nomatch1'}, {'name': 'nomatch2'}]}
+        indexhc([{"health": "green"}], tval)
+        with pytest.raises(ValueError, match=r'resolves to more than one index'):
+            _ = Index(client, action='health', index=idx)
+
+    def test_unacceptable_action(self, client, indexhc, idx):
+        """test_unacceptable_action
+        Should raise ``ValueError`` when an incorrect action is passed
+        """
+        indexhc()
+        hc = Index(client, action='NOTFOUND', index=idx)
+        with pytest.raises(ValueError, match=r'is not an acceptable value for action'):
+            hc.argmap()
+
+    def test_key_not_found(self, client, indexhc, idx):
+        """test_key_not_found
+        Should raise KeyError when key is not in client.cluster.health output
+        """
+        indexhc([{'not': 'found'}])
+        hc = Index(client, action='health', index=idx)
+        with pytest.raises(KeyError, match=r'not in index health output'):
+            hc.check


### PR DESCRIPTION
Add Index health check class

This differs from the Health check class, which checks for cluster-wide status.

This users the client.cat.indices method to get ONLY the health 

```
{'health': 'green'}
```

Where it can be `green`, `yellow`, or `red`.