### PR TITLE
Release 0.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ __pycache__/
 .black
 pylintrc
 pylintrc.toml
+docker_test/.kurl
+http_ca.crt
 
 # Distribution / packaging
 .Python

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.12", None),
-    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.15.0", None),
+    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.15.1", None),
     "elastic-transport": (
         "https://elastic-transport-python.readthedocs.io/en/stable",
         None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = [
     'wait',
 ]
 dependencies = [
-    'elasticsearch8>=8.15.0',
+    'elasticsearch8>=8.15.1',
     'dotmap==1.3.30',
 ]
 
@@ -38,7 +38,7 @@ test = [
     'requests',
     'pytest >=7.2.1',
     'pytest-cov',
-    'es_client==8.15.1',
+    'es_client>=8.13.4',
 ]
 doc = ['sphinx', 'sphinx_rtd_theme']
 
@@ -144,7 +144,7 @@ dependencies = [
     'requests',
     'pytest >=7.2.1',
     'pytest-cov',
-    'es_client==8.13.4',
+    'es_client>=8.13.4',
 ]
 
 [publish.index.repos.main]

--- a/src/es_wait/__init__.py
+++ b/src/es_wait/__init__.py
@@ -1,6 +1,6 @@
 """Top-level init file"""
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 from .exists import Exists
 from .health import Health
 from .index import Index

--- a/src/es_wait/index.py
+++ b/src/es_wait/index.py
@@ -65,7 +65,6 @@ class Index(Waiter):
         """
         res = self.client.cat.indices(index=self.index, format='json', h='health')
         logger.debug('res = %s', res)
-        logger.debug('type(res) = %s', type(res))
         output = res[0]
         check = True
         args = self.argmap()


### PR DESCRIPTION
Removed 1 superfluous debug line from index.py
Version bump elasticsearch8 to 8.15.1
Set optional es_client versions to same release
Added docker_tests/.kurl and http_ca.crt to .gitignore