### PR TITLE
Finally found the Tasks API warning bug

### DIFF
--- a/src/es_wait/__init__.py
+++ b/src/es_wait/__init__.py
@@ -1,6 +1,6 @@
 """Top-level init file"""
 
-__version__ = '0.9.2'
+__version__ = '0.9.3'
 from .exists import Exists
 from .health import Health
 from .index import Index

--- a/src/es_wait/task.py
+++ b/src/es_wait/task.py
@@ -2,8 +2,10 @@
 
 import typing as t
 import logging
+import warnings
 from time import localtime, strftime
 from dotmap import DotMap  # type: ignore
+from elasticsearch8.exceptions import GeneralAvailabilityWarning
 from ._base import Waiter
 
 if t.TYPE_CHECKING:
@@ -72,6 +74,10 @@ class Task(Waiter):
 
         response = {}
         try:
+            # The Tasks API is not yet GA. We need to suppress the warning for now.
+            # This is required after elasticsearch8>=8.16.0 as the warning is raised
+            # from that release onward.
+            warnings.filterwarnings("ignore", category=GeneralAvailabilityWarning)
             response = dict(self.client.tasks.get(task_id=self.task_id))
         except Exception as err:
             msg = (


### PR DESCRIPTION
See [the 8.16.0 Python client release notes](https://github.com/elastic/elasticsearch-py/releases/tag/v8.16.0) for the workaround.

This exact fix is included now in src/es_wait/task.py

I had initially raised an issue at https://github.com/elastic/elasticsearch-py/issues/2765 to learn what transpired.

```diff
--- a/src/es_wait/task.py
+++ b/src/es_wait/task.py
@@ -2,8 +2,10 @@

 import typing as t
 import logging
+import warnings
 from time import localtime, strftime
 from dotmap import DotMap  # type: ignore
+from elasticsearch8.exceptions import GeneralAvailabilityWarning
 from ._base import Waiter

 if t.TYPE_CHECKING:
@@ -72,6 +74,10 @@ class Task(Waiter):

         response = {}
         try:
+            # The Tasks API is not yet GA. We need to suppress the warning for now.
+            # This is required after elasticsearch8>=8.16.0 as the warning is raised
+            # from that release onward.
+            warnings.filterwarnings("ignore", category=GeneralAvailabilityWarning)
             response = dict(self.client.tasks.get(task_id=self.task_id))
         except Exception as err:
             msg = (
```