### PR TITLE
Release prep for 0.9.4

### DIFF
--- a/src/es_wait/__init__.py
+++ b/src/es_wait/__init__.py
@@ -1,6 +1,6 @@
 """Top-level init file"""
 
-__version__ = '0.9.3'
+__version__ = '0.9.4'
 from .exists import Exists
 from .health import Health
 from .index import Index

--- a/src/es_wait/ilm.py
+++ b/src/es_wait/ilm.py
@@ -101,6 +101,13 @@ class IlmPhase(IndexLifecycle):
         :type: bool
         """
         explain = DotMap(self.get_explain_data())
+        if not explain:
+            logger.warning('No ILM Explain data found.')
+            return False
+        logger.debug('ILM Explain data: %s', explain)
+        if not explain.phase:
+            logger.warning('No ILM Phase found.')
+            return False
         logger.info('ILM Phase %s found.', explain.phase)
         if self.phase == 'new':
             logger.debug('Expecting ILM Phase new, or higher')


### PR DESCRIPTION
## Changes

The extremely rapid retry interval used when running PII tool integration tests sometimes resulted in no ILM phase data returned by the `client.ilm.explain_lifecycle()` API call, which would cause tests to fail.

This is now addressed as follows:

```diff
--- a/src/es_wait/ilm.py
+++ b/src/es_wait/ilm.py
@@ -101,6 +101,13 @@ class IlmPhase(IndexLifecycle):
         :type: bool
         """
         explain = DotMap(self.get_explain_data())
+        if not explain:
+            logger.warning('No ILM Explain data found.')
+            return False
+        logger.debug('ILM Explain data: %s', explain)
+        if not explain.phase:
+            logger.warning('No ILM Phase found.')
+            return False
         logger.info('ILM Phase %s found.', explain.phase)
         if self.phase == 'new':
             logger.debug('Expecting ILM Phase new, or higher')
```

Tests are passing in the PII tool with Docker again.

And there was much rejoicing.